### PR TITLE
Update Package.swift dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/realm/realm-swift", .upToNextMajor(from: "10.50.0")),
-        .package(url: "https://github.com/tristanhimmelman/ObjectMapper", .upToNextMinor(from: "4.2.0")),
+        .package(url: "https://github.com/tristanhimmelman/ObjectMapper", .upToNextMinor(from: "4.4.0")),
         .package(url: "https://github.com/anton-plebanovich/RoutableLogger", .upToNextMajor(from: "2.0.0")),
     ],
     targets: [


### PR DESCRIPTION
Resolving an Issue - correct ObjectMapper version can't be resolved by SPM for project root and ObjectMapperAdditions.