### PR TITLE
Update Package.swift - Add static linking options

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,20 @@ let package = Package(
     products: [
         .library(
             name: "ObjectMapperAdditions",
-            type: .dynamic,
             targets: ["ObjectMapperAdditions"]
         ),
         .library(
             name: "ObjectMapperAdditionsRealm",
+            targets: ["ObjectMapperAdditionsRealm"]
+        ),
+// Let users to decide to use dynamic or static linking (SPM builds libraries statically by default)
+        .library(
+            name: "ObjectMapperAdditions-Dynamic",
+            type: .dynamic,
+            targets: ["ObjectMapperAdditions"]
+        ),
+        .library(
+            name: "ObjectMapperAdditionsRealm-Dynamic",
             type: .dynamic,
             targets: ["ObjectMapperAdditionsRealm"]
         )


### PR DESCRIPTION
Let users to decide to use dynamic or static linking (SPM builds libraries statically by default).
Could be fixed in SPM itself in the future but for now this is the only workaround.